### PR TITLE
see #ICTHALES-590 : Evolution LIma DS PCO Dimax

### DIFF
--- a/include/PcoCamera.h
+++ b/include/PcoCamera.h
@@ -67,6 +67,10 @@
 
 #define CAMINFO_CAMERALINK (0x1LL << 16)
 #define CAMINFO_CAMERATYPE (0x1LL << 17)
+
+#define CAMINFO_STORAGEMODE (0x1LL << 18)
+#define CAMINFO_RINGBUFFER (0x1LL << 19)
+
 // ---------------------
 
 #define RESET_CLOSE_INTERFACE 100
@@ -471,6 +475,9 @@ enum enumTraceAcqId
 
 };
 
+#define STG_RECORDER_MODE   "RECORDER"
+#define STG_FIFO_MODE       "FIFO"
+
 #define SIZEARR_stcPcoHWIOSignal 10
 #define SIZESTR_PcoHWIOSignal 1024
 
@@ -604,6 +611,8 @@ namespace lima
 
             DWORD dwPixelRate, dwPixelRateRequested;
             double fTransferRateMHzMax;
+
+            DWORD dwStorageMode;
 
             WORD wLUT_Identifier, wLUT_Parameter;
 
@@ -1014,6 +1023,13 @@ namespace lima
             void getPixelRate(int &val);
             void setPixelRate(int val);
 
+            bool isStorageModeValidValue(std::string stg_mode);
+            void getStorageMode(std::string& stg_mode);
+            void setStorageMode(std::string stg_mode);
+
+            void getRingBuffer(bool &val);
+            void setRingBuffer(bool val);
+
             void getRollingShutterInfo(std::string &o_sn);
             void getRollingShutter(int &val);
             void setRollingShutter(int val);
@@ -1064,6 +1080,12 @@ namespace lima
             void _pco_GetPixelRate(DWORD &pixRate, DWORD &pixRateNext,
                                    int &error);
             // char *_pco_SetCameraSetup(DWORD dwSetup, int &error);
+
+            int _pco_GetStorageMode();
+            void _pco_SetStorageMode(WORD storageMode);
+
+            int _pco_GetRecorderSubmode();
+            void _pco_SetRecorderSubmode(WORD storageMode);
 
             void _pco_SetMetaDataMode(WORD wMetaDataMode, int &error);
 

--- a/src/PcoCamera.cpp
+++ b/src/PcoCamera.cpp
@@ -882,6 +882,10 @@ void Camera::prepareAcq()
     DEF_FNID;
 
     DEB_ALWAYS() << _sprintComment(false, fnId, "[ENTRY]") << _checkLogFiles();
+	
+	bool bRingBuffer;
+	getRingBuffer(bRingBuffer);
+	DEB_ALWAYS() << "Camera::prepareAcq() - [in] bRingBuffer : " << bRingBuffer;
 
     int error;
 
@@ -952,7 +956,7 @@ void Camera::prepareAcq()
 
         getRecorderForcedFifo(forced);
 
-        if ((trig_mode == ExtTrigSingle) && (iRequestedFrames > 0))
+        if (bRingBuffer) // || ((trig_mode == ExtTrigSingle) && (iRequestedFrames > 0)))
         {
             mode = RecRing;
         }
@@ -1146,6 +1150,9 @@ void Camera::prepareAcq()
     //------------------------------------------------- checking nr of frames
     // for cams with memory
 #endif
+
+	getRingBuffer(bRingBuffer);
+	DEB_ALWAYS() << "Camera::prepareAcq() - [out] bRingBuffer : " << bRingBuffer;
 }
 
 //==========================================================================================================

--- a/src/PcoCameraSdk.cpp
+++ b/src/PcoCameraSdk.cpp
@@ -2323,6 +2323,120 @@ void Camera::_pco_GetPixelRate(DWORD &pixRateActual, DWORD &pixRateNext,
 
 #endif
 }
+
+//=================================================================================================
+// Storage mode
+//=================================================================================================
+// _pco_GetStorageMode
+int Camera::_pco_GetStorageMode()
+{
+    DEB_MEMBER_FUNCT();
+    DEF_FNID;
+    const char *msg;
+    WORD wStorageMode;
+	int err;
+
+#ifndef __linux__
+
+    PCO_FN2(err, msg, PCO_GetStorageMode, m_handle, &wStorageMode);
+    PCO_THROW_OR_TRACE(err, msg);
+ 
+#else
+
+    err = PCO_GetStorageMode(m_handle, &wStorageMode);
+    msg = "PCO_GetStorageMode";
+    PCO_CHECK_ERROR(err, msg);
+    if (err != 0)
+        wStorageMode = 0;
+
+#endif
+    m_pcoData->storage_mode = wStorageMode;
+	m_pcoData->dwStorageMode = wStorageMode;
+    return wStorageMode;
+}
+
+// _pco_SetStorageMode
+void Camera::_pco_SetStorageMode(WORD wStorageMode)
+{
+    DEB_MEMBER_FUNCT();
+    DEF_FNID;
+    int error = 0;
+    const char *msg;
+
+#ifndef __linux__
+
+    PCO_FN2(error, msg, PCO_SetStorageMode, m_handle, wStorageMode);
+    PCO_THROW_OR_TRACE(error, msg);
+
+#else
+
+    error = PCO_SetStorageMode(m_handle, wStorageMode);
+    msg = "PCO_SetStorageMode";
+    PCO_THROW_OR_TRACE(error, msg);
+
+#endif
+
+    m_pcoData->storage_mode = wStorageMode;
+	m_pcoData->dwStorageMode = wStorageMode;
+}
+
+//=================================================================================================
+//
+//=================================================================================================
+int Camera::_pco_GetRecorderSubmode()
+{
+    DEB_MEMBER_FUNCT();
+    DEF_FNID;
+    const char *msg;
+
+    WORD wRecSubmode;
+    int error;
+
+#ifndef __linux__
+
+    PCO_FN2(error, msg, PCO_GetRecorderSubmode, m_handle, &wRecSubmode);
+    if (error)
+    {
+        PCO_THROW_OR_TRACE(error, msg);
+    }
+#else
+
+    error = PCO_GetRecorderSubmode(m_handle, &wRecSubmode);
+    msg = "PCO_GetRecorderSubmode";
+    PCO_THROW_OR_TRACE(error, msg);
+    
+#endif
+	m_pcoData->recorder_submode = wRecSubmode;
+    return wRecSubmode;
+}
+
+// _pco_SetRecorderSubmode
+void Camera::_pco_SetRecorderSubmode(WORD recSubmode)
+{
+    DEB_MEMBER_FUNCT();
+    DEF_FNID;
+    const char *msg;
+
+    int error;
+
+#ifndef __linux__
+
+    PCO_FN2(error, msg, PCO_SetRecorderSubmode, m_handle, recSubmode);
+    if (error)
+    {
+        PCO_THROW_OR_TRACE(error, msg);
+    }
+#else
+
+    error = PCO_SetRecorderSubmode(m_handle, recSubmode);
+    msg = "PCO_SetRecorderSubmode";
+    PCO_THROW_OR_TRACE(error, msg);
+    
+#endif
+	m_pcoData->recorder_submode = recSubmode;
+}
+
+
 //=================================================================================================
 // ----------------------------------------- storage mode (recorder + sequence)
 // current storage mode

--- a/src/PcoCameraSip.cpp
+++ b/src/PcoCameraSip.cpp
@@ -129,8 +129,8 @@ void Camera::getRingBuffer(bool &val)
     getStorageMode(stg_mode);
     if (stg_mode == STG_RECORDER_MODE)
     {
-        int wRecSubmode = _pco_GetRecorderSubmode();
-        if (wRecSubmode == 1)
+        WORD wRecSubmode = _pco_GetRecorderSubmode();
+        if (wRecSubmode == 0x0001)
             val = true;
         else
             val = false;
@@ -148,6 +148,7 @@ void Camera::setRingBuffer(bool val)
     {
         // Set storage mode in recoder mode  
         setStorageMode(STG_RECORDER_MODE);
+		m_sync->setTrigMode(TrigMode::ExtTrigSingle);
     }
     // Next, Change Recorder submode
     _pco_SetRecorderSubmode(recSubmode);

--- a/src/PcoCameraSip.cpp
+++ b/src/PcoCameraSip.cpp
@@ -80,6 +80,81 @@ void Camera::setPixelRate(int val)
 }
 
 //====================================================================
+// SIP STORAGE MODE - attributes
+//====================================================================
+bool Camera::isStorageModeValidValue(std::string stg_mode)
+{
+	std::string stg_upper;
+	std::transform(stg_mode.begin(), stg_mode.end(), std::back_inserter(stg_upper), ::toupper);
+	
+    return (stg_upper == STG_RECORDER_MODE || stg_upper == STG_FIFO_MODE);
+}
+
+void Camera::getStorageMode(std::string &stg_mode)
+{
+    DWORD wStorageMode;
+    wStorageMode = _pco_GetStorageMode();
+
+    switch((int)wStorageMode) 
+    {
+        case 0: stg_mode = STG_RECORDER_MODE; break;
+        case 1: stg_mode = STG_FIFO_MODE; break;
+        default: break;
+    }
+}
+
+void Camera::setStorageMode(std::string stg_mode)
+{
+    DWORD wStorageMode;
+
+	std::string stg_upper;
+	std::transform(stg_mode.begin(), stg_mode.end(), std::back_inserter(stg_upper), ::toupper);
+		
+    if (stg_upper == STG_RECORDER_MODE)
+        wStorageMode = 0x0000;
+    else if (stg_upper == STG_FIFO_MODE)
+        wStorageMode = 0x0001;
+    else
+        return;
+
+    _pco_SetStorageMode(wStorageMode);
+}
+
+//====================================================================
+// SIP RING Buffer - attributes
+//====================================================================
+void Camera::getRingBuffer(bool &val)
+{
+    std::string stg_mode;
+    getStorageMode(stg_mode);
+    if (stg_mode == STG_RECORDER_MODE)
+    {
+        int wRecSubmode = _pco_GetRecorderSubmode();
+        if (wRecSubmode == 1)
+            val = true;
+        else
+            val = false;
+    }
+    else
+        val = false;
+}
+
+void Camera::setRingBuffer(bool val)
+{
+    
+    WORD recSubmode;
+    recSubmode = (int)val;      // 0: sequence, 1: ring buffer
+    if (val)
+    {
+        // Set storage mode in recoder mode  
+        setStorageMode(STG_RECORDER_MODE);
+    }
+    // Next, Change Recorder submode
+    _pco_SetRecorderSubmode(recSubmode);
+
+}
+
+//====================================================================
 //====================================================================
 void Camera::getAcqTimeoutRetry(int &val)
 {

--- a/src/PcoCameraUtils.cpp
+++ b/src/PcoCameraUtils.cpp
@@ -3108,6 +3108,25 @@ char *Camera::_camInfo(char *ptr, char *ptrMax, long long int flag)
             (int)m_pcoData->temperature.sSetpoint);
     }
 
+	//--------------- storage mode
+    if (flag & CAMINFO_STORAGEMODE)
+    {
+        ptr += __sprintfSExt(ptr, ptrMax - ptr, "* storageMode \n");
+        ptr += __sprintfSExt(ptr, ptrMax - ptr, "%s", m_pcoData->storage_mode ? STG_FIFO_MODE : STG_RECORDER_MODE);
+    }
+	
+	//--------------- ring buffer
+    if (flag & CAMINFO_RINGBUFFER)
+    {
+        ptr += __sprintfSExt(ptr, ptrMax - ptr, "* ringBuffer \n");
+		std::string ringBuffer;
+		if ((m_pcoData->storage_mode == 0 || m_pcoData->dwStorageMode == 0) && m_pcoData->recorder_submode == 1)
+            ringBuffer = "1";
+		else 
+			ringBuffer = "0";
+        ptr += __sprintfSExt(ptr, ptrMax - ptr, "%s", ringBuffer.c_str());
+    }
+	
     if (flag & CAMINFO_BLOCK)
     {
         lgbuff = ptrMax - ptr;
@@ -3117,7 +3136,7 @@ char *Camera::_camInfo(char *ptr, char *ptrMax, long long int flag)
                              "size[%lld B]) [end]\n",
                              lgbuff, used, lgbuffmax);
     }
-
+	
     return ptr;
 }
 

--- a/src/PcoCameraWin.cpp
+++ b/src/PcoCameraWin.cpp
@@ -1128,21 +1128,27 @@ void Camera::startAcq()
         int forcedFifo = 0;
         getRecorderForcedFifo(forcedFifo);
 
+		DEB_ALWAYS() << "Camera::startAcq() - NbFrames: " << iRequestedFrames << ", forcedFifo: " << forcedFifo;
         if ((iRequestedFrames > 0) && (forcedFifo == 0))
+
         {
+			DEB_ALWAYS() << "Camera::startAcq() - triggerMode: " << trig_mode;
             if ((trig_mode == ExtTrigSingle))
             {
+				DEB_ALWAYS() << "Camera::startAcq() - _pco_acq_thread_dimax_trig_single... ";
                 _beginthread(_pco_acq_thread_dimax_trig_single, 0,
                              (void *)this);
             }
             else
             {
+				DEB_ALWAYS() << "Camera::startAcq() - _pco_acq_thread_dimax... ";
                 _beginthread(_pco_acq_thread_dimax, 0,
                              (void *)this); // normal mode
             }
         }
         else
         {
+			DEB_ALWAYS() << "Camera::startAcq() - _pco_acq_thread_dimax_live... ";
             _beginthread(_pco_acq_thread_dimax_live, 0, (void *)this);
         }
         m_pcoData->traceAcq.msStartAcqEnd = msElapsedTime(tStart);


### PR DESCRIPTION
Il y a quelques évolutions souhaitable dans le DS pour le PCO dimax, pour rajouter des fonctionnalités disponible dans le CamWare, et a priori disponible avec le DS utilisé a l'ESRF - Mario va pouvoir confirmer.

(1) Accès au mode "ring buffer" (acquisition en RAM en continue, arrêt avec un post-trigger). exemple d'usage:

on lance une acquisition , qui tourne "indéfiniment" , en enregistrant en RAM les images, qui sont écrasées au fur à mesure (ring buffer)
une fois que l’évènement de l’expérience est arrivé (eg une bille qui tombe): l'utilisateur arrête manuellement l'acquisition
on récupère les N dernières images qui normalement contiendront la bille tombée
pour cela il faut que les images soient remontées dans le device pour que l'utilisateur puisse voir en direct (cf mode live ci dessous)
(2) Visualiser les images en cours d'acquisition en direct, avant le lecteur complete du RAM.